### PR TITLE
Limited-scores-records

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
+      scores = Score.all.includes(:user).limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {
@@ -43,7 +43,7 @@ module Api
       if user.blank?
         render json: {
           errors: [
-            "User not found"
+            'User not found'
           ]
         }, status: :not_found
         return

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -34,7 +34,7 @@ module Api
       if user.blank?
         render json: {
           error: [
-            "User not found"
+            'User not found'
           ]
         }, status: :not_found
         return
@@ -42,10 +42,10 @@ module Api
 
       render json: {
         user: {
-        id: user.id,
-        name: user.name
+          id: user.id,
+          name: user.name
         }
-      } if user
+      }
     end
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -103,5 +103,18 @@ describe Api::ScoresController, type: :request do
       expect(response).not_to have_http_status(:ok)
       expect(Score.count).to eq score_count
     end
+
+    it 'should limit feed length to 25' do
+      30.times do
+        create(:score, user: @user1, total_score: 101, played_at: '2021-07-15')
+      end
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 end


### PR DESCRIPTION
Fixes: issue url

We used " .limit(25) " so we can take only 25 most recent records from our db : 

<img width="725" alt="image" src="https://user-images.githubusercontent.com/107692176/179931692-5f54d139-3de8-4ea7-bd87-64dc0e6908b5.png">


Result after rspec command : 

<img width="738" alt="image" src="https://user-images.githubusercontent.com/107692176/179931239-b0f3515d-cbbd-4bb2-b011-365758b99b72.png">

Result after rubocop command : 

<img width="725" alt="image" src="https://user-images.githubusercontent.com/107692176/179931381-21221478-be6d-4f4f-83d4-42ef1442cee6.png">

